### PR TITLE
custom serializers to allow custom seralization of certain object typ…

### DIFF
--- a/json-view/src/test/java/com/monitorjbl/json/model/CustomType.java
+++ b/json-view/src/test/java/com/monitorjbl/json/model/CustomType.java
@@ -1,0 +1,44 @@
+package com.monitorjbl.json.model;
+
+public class CustomType
+{
+    private long sid=0l;
+    private String name="name";
+    
+    
+    public CustomType(long sid,String name){
+        this.setSid( sid );
+        this.setName( name );
+    }
+    
+    public long getSid()
+    {
+        return sid;
+    }
+
+    public void setSid( long sid )
+    {
+        this.sid = sid;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName( String name )
+    {
+        this.name = name;
+    } 
+    
+    
+    public boolean equals(Object obj){
+        if(obj instanceof CustomType){
+            CustomType c=(CustomType)obj;
+            return c.name.equals( name ) && c.sid==sid;
+        }else{
+            return false;
+        }
+    }
+    
+}

--- a/json-view/src/test/java/com/monitorjbl/json/model/CustomTypeSerializer.java
+++ b/json-view/src/test/java/com/monitorjbl/json/model/CustomTypeSerializer.java
@@ -1,0 +1,27 @@
+package com.monitorjbl.json.model;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class CustomTypeSerializer
+    extends StdSerializer<CustomType>
+{
+    private static final long serialVersionUID = 5275226323866715671L;
+
+    public CustomTypeSerializer()
+    {
+        super( CustomType.class, true );
+    }
+
+    @Override
+    public void serialize( CustomType value, JsonGenerator jgen, SerializerProvider provider )
+        throws IOException, JsonGenerationException
+    {
+        jgen.writeString( value.getSid() + "[" + value.getName() + "]" );
+    }
+
+}

--- a/json-view/src/test/java/com/monitorjbl/json/model/TestObject.java
+++ b/json-view/src/test/java/com/monitorjbl/json/model/TestObject.java
@@ -41,6 +41,7 @@ public class TestObject implements TestInterface {
   private URI uri;
   private Class cls;
   private BigDecimal bigDecimal;
+  private CustomType custom;
 
   public String getStr1() {
     return str1;
@@ -216,5 +217,13 @@ public class TestObject implements TestInterface {
 
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
+  }
+  
+  public CustomType getCustom() {
+    return custom;
+  }
+
+  public void setCustom(CustomType custom) {
+    this.custom = custom;
   }
 }

--- a/spring-json-view/src/main/java/com/monitorjbl/json/JsonViewMessageConverter.java
+++ b/spring-json-view/src/main/java/com/monitorjbl/json/JsonViewMessageConverter.java
@@ -1,20 +1,24 @@
 package com.monitorjbl.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
-import java.io.IOException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class JsonViewMessageConverter extends MappingJackson2HttpMessageConverter {
 
+    private JsonViewSerializer serializer=new JsonViewSerializer();
+    
   public JsonViewMessageConverter() {
     super();
     ObjectMapper defaultMapper = new ObjectMapper();
     SimpleModule module = new SimpleModule();
-    module.addSerializer(JsonView.class, new JsonViewSerializer());
+    module.addSerializer(JsonView.class, this.serializer);
     defaultMapper.registerModule(module);
     setObjectMapper(defaultMapper);
   }
@@ -22,11 +26,38 @@ public class JsonViewMessageConverter extends MappingJackson2HttpMessageConverte
   public JsonViewMessageConverter(ObjectMapper mapper) {
     super();
     SimpleModule module = new SimpleModule();
-    module.addSerializer(JsonView.class, new JsonViewSerializer());
+    module.addSerializer(JsonView.class, this.serializer);
     mapper.registerModule(module);
     setObjectMapper(mapper);
   }
 
+  /**
+   * Registering custom serializer allows to the JSonView to deal with custom serializations for certains field types.<br>
+   * This way you could register for instance a JODA serialization as  a DateTimeSerializer. <br>
+   * Thus, when JSonView find a field of that type (DateTime), it will delegate the serialization to the serializer specified.<br>
+   * Example:<br>
+   * <code>
+   *   JsonViewSupportFactoryBean bean = new JsonViewSupportFactoryBean( mapper );
+   *   bean.registerCustomSerializer( DateTime.class, new DateTimeSerializer() );
+   * </code>
+   * @param <T> Type class of the serializer
+   * @param class1 {@link Class} the class type you want to add a custom serializer 
+   * @param forType {@link JsonSerializer} the serializer you want to apply for that type
+   */
+  public <T> void registerCustomSerializer( Class<T> class1, JsonSerializer<T> forType )
+  {
+      this.serializer.registerCustomSerializer(class1, forType );
+  }
+  
+  /**
+   * Unregister a previously registtered serializer. @see registerCustomSerializer
+   * @param class1
+   */
+  public <T> void unregisterCustomSerializer( Class<T> class1 )
+  {
+      this.serializer.unregisterCustomSerializer(class1);
+  }
+  
   @Override
   protected void writeInternal(Object object, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
     super.writeInternal(object, outputMessage);

--- a/spring-json-view/src/main/java/com/monitorjbl/json/JsonViewSupportFactoryBean.java
+++ b/spring-json-view/src/main/java/com/monitorjbl/json/JsonViewSupportFactoryBean.java
@@ -1,6 +1,9 @@
 package com.monitorjbl.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -9,9 +12,8 @@ import org.springframework.web.servlet.mvc.method.annotation.HttpEntityMethodPro
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JsonViewSupportFactoryBean implements InitializingBean {
 
@@ -47,6 +49,35 @@ public class JsonViewSupportFactoryBean implements InitializingBean {
         break;
       }
     }
+  }
+
+
+  /**
+   * Registering custom serializer allows to the JSonView to deal with custom serializations for certains field types.<br>
+   * This way you could register for instance a JODA serialization as  a DateTimeSerializer. <br>
+   * Thus, when JSonView find a field of that type (DateTime), it will delegate the serialization to the serializer specified.<br>
+   * Example:<br>
+   * <code>
+   *   JsonViewSupportFactoryBean bean = new JsonViewSupportFactoryBean( mapper );
+   *   bean.registerCustomSerializer( DateTime.class, new DateTimeSerializer() );
+   * </code>
+   * @param <T> Type class of the serializer
+   * @param class1 {@link Class} the class type you want to add a custom serializer 
+   * @param forType {@link JsonSerializer} the serializer you want to apply for that type
+   */
+  public <T> void registerCustomSerializer( Class<T> class1, JsonSerializer<T> forType )
+  {
+      this.converter.registerCustomSerializer( class1, forType );
+  }
+  
+  
+  /**
+   * Unregister a previously registtered serializer. @see registerCustomSerializer
+   * @param class1
+   */
+  public <T> void unregisterCustomSerializer( Class<T> class1 )
+  {
+      this.converter.unregisterCustomSerializer(class1);
   }
 
 }


### PR DESCRIPTION
…es like JODA date fields
Hi! I did a small change to allow to register custom serialization objects. I found a problem with Joda serialization objects, and could be a generic problem: Joda has its own JodaModule to be registered and parse Joda Date fields, but when I tried to use the JsonView module, it doesn't use anymore the JodaModule to serialize Dates fields.
With this change you can register to the JsonView any serializer and it will delegate the responsability to seralize the type you specified when a field of that type is found.
what do you think about this change? Thanks!
