### PR TITLE
Dont remove get from field name if field name is get

### DIFF
--- a/json-view/src/main/java/com/monitorjbl/json/JsonViewSerializer.java
+++ b/json-view/src/main/java/com/monitorjbl/json/JsonViewSerializer.java
@@ -791,6 +791,9 @@ public class JsonViewSerializer extends JsonSerializer<JsonView> {
     }
 
     private String getFieldNameFromGetter(Method method) {
+      if (method.getName().equals("get")) {
+    	  return method.getName();
+      }
       String name = method.getName().replaceFirst("get", "");
       return name.substring(0, 1).toLowerCase() + name.substring(1);
     }


### PR DESCRIPTION
In Spring Boot 2.1 with the `org.springframework.data.domain.Page` interface which extends `org.springframework.data.domain.Slice`->`org.springframework.data.util.Streamable` which contains a method name `get()`

Due to this, when using json-view on `org.springframework.data.domain.Page` , an out of bound will occur due to a method name being `get()`, hence a check is needed